### PR TITLE
Secure and required text entry

### DIFF
--- a/dialog.xcodeproj/xcuserdata/rea094.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/dialog.xcodeproj/xcuserdata/rea094.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "A4484579-600A-427F-B4ED-249EDA4C71FA"
    type = "1"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "17F3410B-36F5-4EEB-B2A1-24FC70519B96"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "dialog/extras/TrackProgress.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "143"
+            endingLineNumber = "143"
+            landmarkName = "end()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2061</string>
+	<string>2095</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2095</string>
+	<string>2115</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2217</string>
+	<string>2219</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2137</string>
+	<string>2159</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2219</string>
+	<string>2253</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2115</string>
+	<string>2137</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2159</string>
+	<string>2217</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/UI/ButtonView.swift
+++ b/dialog/UI/ButtonView.swift
@@ -66,7 +66,7 @@ struct ButtonView: View {
 
         Button(action: {
             observedDialogContent.end()
-            buttonAction(action: self.button1action, exitCode: 0, executeShell: self.buttonShellAction)
+            buttonAction(action: self.button1action, exitCode: 0, executeShell: self.buttonShellAction, observedObject: observedDialogContent)
             
         }, label: {
             Text(button1Text)

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -18,7 +18,15 @@ struct DropdownView: View {
     var dropdownTitle: String = cloptions.dropdownTitle.value
     var showDropdown: Bool = cloptions.dropdownValues.present
     var defaultValue: String = ""
+    var fieldwidth: CGFloat = 0
     
+    init() {
+        if cloptions.hideIcon.present {
+            fieldwidth = appvars.windowWidth
+        } else {
+            fieldwidth = appvars.windowWidth - appvars.iconWidth
+        }
+    }
         
     var body: some View {
         if showDropdown {
@@ -29,8 +37,7 @@ struct DropdownView: View {
                 Text(dropdownTitle)
                     .bold()
                     .font(.system(size: 15))
-                    //.frame(alignment: .leading)
-                    .frame(width: appvars.windowWidth/5, alignment: .leading)
+                    .frame(idealWidth: fieldwidth*0.20, maxWidth: 90, alignment: .leading)
                 Spacer()
                     .frame(width: 20)
                 Picker("", selection: $selectedOption)
@@ -40,8 +47,7 @@ struct DropdownView: View {
                     }
                 }
                 .pickerStyle(DefaultPickerStyle())
-                .frame(width: appvars.windowWidth/3, alignment: .trailing)
-                //.frame(maxWidth: 450, alignment: .trailing)
+                .frame(idealWidth: fieldwidth*0.50, maxWidth: 200, alignment: .trailing)
                 .onChange(of: selectedOption) { _ in
                     //update appvars with the option that was selected. this will be printed to stdout on exit
                     appvars.selectedOption = selectedOption
@@ -49,7 +55,6 @@ struct DropdownView: View {
                 }
                 Spacer()
             }
-            //.frame(maxWidth: 500)
         }
     }
 }

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -29,8 +29,10 @@ struct DropdownView: View {
                 Text(dropdownTitle)
                     .bold()
                     .font(.system(size: 15))
-                    .frame(alignment: .leading)
+                    //.frame(alignment: .leading)
+                    .frame(width: appvars.windowWidth/5, alignment: .leading)
                 Spacer()
+                    .frame(width: 20)
                 Picker("", selection: $selectedOption)
                 {
                     ForEach(dropdownValues, id: \.self) {
@@ -38,14 +40,16 @@ struct DropdownView: View {
                     }
                 }
                 .pickerStyle(DefaultPickerStyle())
-                .frame(maxWidth: 450, alignment: .trailing)
+                .frame(width: appvars.windowWidth/3, alignment: .trailing)
+                //.frame(maxWidth: 450, alignment: .trailing)
                 .onChange(of: selectedOption) { _ in
                     //update appvars with the option that was selected. this will be printed to stdout on exit
                     appvars.selectedOption = selectedOption
                     appvars.selectedIndex = dropdownValues.firstIndex {$0 == selectedOption} ?? -1
                 }
+                Spacer()
             }
-            .frame(maxWidth: 500)
+            //.frame(maxWidth: 500)
         }
     }
 }

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -37,7 +37,7 @@ struct DropdownView: View {
                 Text(dropdownTitle)
                     .bold()
                     .font(.system(size: 15))
-                    .frame(idealWidth: fieldwidth*0.20, maxWidth: 90, alignment: .leading)
+                    .frame(idealWidth: fieldwidth*0.20, maxWidth: 150, alignment: .leading)
                 Spacer()
                     .frame(width: 20)
                 Picker("", selection: $selectedOption)
@@ -47,7 +47,7 @@ struct DropdownView: View {
                     }
                 }
                 .pickerStyle(DefaultPickerStyle())
-                .frame(idealWidth: fieldwidth*0.50, maxWidth: 200, alignment: .trailing)
+                .frame(idealWidth: fieldwidth*0.50, maxWidth: 300, alignment: .trailing)
                 .onChange(of: selectedOption) { _ in
                     //update appvars with the option that was selected. this will be printed to stdout on exit
                     appvars.selectedOption = selectedOption

--- a/dialog/UI/MessageContentView.swift
+++ b/dialog/UI/MessageContentView.swift
@@ -72,13 +72,15 @@ struct MessageContent: View {
                     Spacer()
                     VStack {
                         TextEntryView()
-                            .padding(.leading, 50)
-                            .padding(.trailing, 50)
+                            //.padding(.leading, 50)
+                            //.padding(.trailing, 50)
+                            .padding(.bottom, 10)
                             .border(appvars.debugBorderColour, width: 2)
 
                         DropdownView()
-                            .padding(.leading, 50)
-                            .padding(.trailing, 50)
+                            //.padding(.leading, 50)
+                            //.padding(.trailing, 50)
+                            .padding(.bottom, 10)
                             .border(appvars.debugBorderColour, width: 2)
                     }
                 }

--- a/dialog/UI/MessageContentView.swift
+++ b/dialog/UI/MessageContentView.swift
@@ -14,6 +14,8 @@ struct MessageContent: View {
     @ObservedObject var observedDialogContent : DialogUpdatableContent
     @State private var contentHeight: CGFloat = 40
     
+    var fieldPadding: CGFloat = 10
+    
     var messageColour : NSColor = NSColor(appvars.messageFontColour)
     
     var useDefaultStyle = true
@@ -33,6 +35,12 @@ struct MessageContent: View {
     let messageContentOption: String = cloptions.messageOption.value
     let theAllignment: Alignment = .topLeading
     
+    init(observedDialogContent : DialogUpdatableContent) {
+        self.observedDialogContent = observedDialogContent
+        if cloptions.hideIcon.present {
+            fieldPadding = 40
+        }
+    }
     
     var body: some View {
         
@@ -69,7 +77,7 @@ struct MessageContent: View {
                 
                 Spacer()
                 HStack() {
-                    Spacer()
+                    //Spacer()
                     VStack {
                         TextEntryView()
                             //.padding(.leading, 50)
@@ -85,8 +93,8 @@ struct MessageContent: View {
                     }
                 }
             }
-            .padding(.leading, 40)
-            .padding(.trailing, 40)
+            .padding(.leading, fieldPadding)
+            .padding(.trailing, fieldPadding)
         }
     }
 }

--- a/dialog/UI/MessageContentView.swift
+++ b/dialog/UI/MessageContentView.swift
@@ -79,7 +79,7 @@ struct MessageContent: View {
                 HStack() {
                     //Spacer()
                     VStack {
-                        TextEntryView()
+                        TextEntryView(observedDialogContent: observedDialogContent)
                             //.padding(.leading, 50)
                             //.padding(.trailing, 50)
                             .padding(.bottom, 10)

--- a/dialog/UI/TextEntryView.swift
+++ b/dialog/UI/TextEntryView.swift
@@ -31,20 +31,28 @@ struct TextEntryView: View {
                 ForEach(0..<textFieldLabels.count, id: \.self) {i in
                     HStack {
                         Spacer()
-                        Text(textFieldLabels[i])
+                        Text(String(textFieldLabels[i]).components(separatedBy: ",")[0])
                             .bold()
                             .font(.system(size: 15))
-                            .frame(alignment: .leading)
+                            .frame(width: appvars.windowWidth/5, alignment: .leading)
                         Spacer()
-                        TextField("", text: $textFieldValue[i])
-                            .frame(maxWidth: 450, alignment: .trailing)
-                            .onChange(of: textFieldValue[i], perform: { value in
-                                //update appvars with the text that was entered. this will be printed to stdout on exit
-                                appvars.textFieldText[i] = textFieldValue[i]
-                            })
+                            .frame(width: 20)
+                        HStack {
+                            if textFieldLabels[i].lowercased().contains("password") {
+                                SecureField("", text: $textFieldValue[i])
+                            } else {
+                                TextField("", text: $textFieldValue[i])
+                            }
+                        }
+                        .frame(width: appvars.windowWidth/3, alignment: .trailing)
+                        .onChange(of: textFieldValue[i], perform: { value in
+                            //update appvars with the text that was entered. this will be printed to stdout on exit
+                            appvars.textFieldText[i] = textFieldValue[i]
+                        })
+                        Spacer()
                     }
                 }
-            }.frame(maxWidth: 500)
+            }//.frame(maxWidth: 500)
         }
     }
 }

--- a/dialog/UI/TextEntryView.swift
+++ b/dialog/UI/TextEntryView.swift
@@ -9,25 +9,21 @@ import SwiftUI
 
 struct TextEntryView: View {
     
-    @State var textFieldValue = Array(repeating: "", count: 64)
-    @State var textFieldValuej = Array(repeating: "", count: 64)
-    //@State var textFieldValue = ""
-    //var textFieldLabel = CLOptionText(OptionName: cloptions.textField)
-    let textFieldLabels = appvars.textOptionsArray
-    //let textfieldLabels2 = textFields
+    @ObservedObject var observedDialogContent : DialogUpdatableContent
+    
+    @State var textFieldValue = Array(repeating: "", count: textFields.count)
+    
     var textFieldPresent: Bool = false
     var fieldwidth: CGFloat = 0
     var highlight = [Color]()
     
-    init() {
+    init(observedDialogContent : DialogUpdatableContent) {
+        self.observedDialogContent = observedDialogContent
         if cloptions.textField.present {
             textFieldPresent = true
-            for i in 0..<textFields.count {
+            for _ in 0..<textFields.count {
                 textFieldValue.append(" ")
                 highlight.append(Color.clear)
-                if textFields[i].required {
-                    highlight[i] = Color.red
-                }
             }
         }
         if cloptions.hideIcon.present {
@@ -35,34 +31,45 @@ struct TextEntryView: View {
         } else {
             fieldwidth = appvars.windowWidth - appvars.iconWidth
         }
-        print("highlight array is \(highlight)")
     }
     
     var body: some View {
         if textFieldPresent {
             VStack {
-                ForEach(0..<textFields.count, id: \.self) {j in
+                ForEach(0..<textFields.count, id: \.self) {index in
                     HStack {
                         Spacer()
-                        Text(textFields[j].title)
+                        Text(textFields[index].title)
                             .bold()
                             .font(.system(size: 15))
-                            .frame(idealWidth: fieldwidth*0.20, alignment: .leading)
+                            .frame(idealWidth: fieldwidth*0.20, maxWidth: 150, alignment: .leading)
                         Spacer()
                             .frame(width: 20)
                         HStack {
-                            if textFields[j].secure {
-                                SecureField("", text: $textFieldValuej[j])
-                                    .border(highlight[j])
+                            if textFields[index].secure {
+                                ZStack() {
+                                    SecureField("", text: $textFieldValue[index])
+                                        .disableAutocorrection(true)
+                                        .textContentType(.password)
+                                        //.border(highlight[index])
+                                        .overlay(RoundedRectangle(cornerRadius: 5)
+                                                    .stroke(observedDialogContent.requiredTextfieldHighlight[index], lineWidth: 1))
+
+                                    Image(systemName: "lock.fill")
+                                        .foregroundColor(stringToColour("#008815")).opacity(0.5)
+                                            .frame(idealWidth: fieldwidth*0.50, maxWidth: 300, alignment: .trailing)
+                                }
                             } else {
-                                TextField("", text: $textFieldValuej[j])
-                                    .border(highlight[j])
+                                TextField("", text: $textFieldValue[index])
+                                    //.border(highlight[index])
+                                    .overlay(RoundedRectangle(cornerRadius: 5)
+                                                .stroke(observedDialogContent.requiredTextfieldHighlight[index], lineWidth: 1))
                             }
                         }
-                        .frame(idealWidth: fieldwidth*0.50, alignment: .trailing)
-                        .onChange(of: textFieldValuej[j], perform: { value in
+                        .frame(idealWidth: fieldwidth*0.50, maxWidth: 300, alignment: .trailing)
+                        .onChange(of: textFieldValue[index], perform: { value in
                             //update appvars with the text that was entered. this will be printed to stdout on exit
-                            textFields[j].value = textFieldValuej[j]
+                            textFields[index].value = textFieldValue[index]
                         })
                         Spacer()
                     }
@@ -72,8 +79,4 @@ struct TextEntryView: View {
     }
 }
 
-struct TextEntryView_Previews: PreviewProvider {
-    static var previews: some View {
-        TextEntryView()
-    }
-}
+

--- a/dialog/UI/TextEntryView.swift
+++ b/dialog/UI/TextEntryView.swift
@@ -10,18 +10,24 @@ import SwiftUI
 struct TextEntryView: View {
     
     @State var textFieldValue = Array(repeating: "", count: 64)
+    @State var textFieldValuej = Array(repeating: "", count: 64)
     //@State var textFieldValue = ""
     //var textFieldLabel = CLOptionText(OptionName: cloptions.textField)
     let textFieldLabels = appvars.textOptionsArray
+    //let textfieldLabels2 = textFields
     var textFieldPresent: Bool = false
     var fieldwidth: CGFloat = 0
-    
+    var highlight = [Color]()
     
     init() {
         if cloptions.textField.present {
             textFieldPresent = true
-            for _ in textFieldLabels {
+            for i in 0..<textFieldLabels.count {
                 textFieldValue.append(" ")
+                highlight.append(Color.clear)
+                if textFields[i].required {
+                    highlight[i] = Color.red
+                }
             }
         }
         if cloptions.hideIcon.present {
@@ -34,26 +40,28 @@ struct TextEntryView: View {
     var body: some View {
         if textFieldPresent {
             VStack {
-                ForEach(0..<textFieldLabels.count, id: \.self) {i in
+                ForEach(0..<textFields.count, id: \.self) {j in
                     HStack {
                         Spacer()
-                        Text(String(textFieldLabels[i]).components(separatedBy: ",")[0])
+                        Text(textFields[j].title)
                             .bold()
                             .font(.system(size: 15))
                             .frame(idealWidth: fieldwidth*0.20, maxWidth: 90, alignment: .leading)
                         Spacer()
                             .frame(width: 20)
                         HStack {
-                            if textFieldLabels[i].lowercased().contains("password") {
-                                SecureField("", text: $textFieldValue[i])
+                            if textFields[j].secure {
+                                SecureField("", text: $textFieldValuej[j])
+                                    .border(highlight[j])
                             } else {
-                                TextField("", text: $textFieldValue[i])
+                                TextField("", text: $textFieldValuej[j])
+                                    .border(highlight[j])
                             }
                         }
                         .frame(idealWidth: fieldwidth*0.50, maxWidth: 200, alignment: .trailing)
-                        .onChange(of: textFieldValue[i], perform: { value in
+                        .onChange(of: textFieldValuej[j], perform: { value in
                             //update appvars with the text that was entered. this will be printed to stdout on exit
-                            appvars.textFieldText[i] = textFieldValue[i]
+                            textFields[j].value = textFieldValuej[j]
                         })
                         Spacer()
                     }

--- a/dialog/UI/TextEntryView.swift
+++ b/dialog/UI/TextEntryView.swift
@@ -13,17 +13,22 @@ struct TextEntryView: View {
     
     @State var textFieldValue = Array(repeating: "", count: textFields.count)
     
+    @State private var animationAmount = 1.0
+    
     var textFieldPresent: Bool = false
     var fieldwidth: CGFloat = 0
-    var highlight = [Color]()
+    var requiredFieldsPresent : Bool = false
     
     init(observedDialogContent : DialogUpdatableContent) {
         self.observedDialogContent = observedDialogContent
         if cloptions.textField.present {
             textFieldPresent = true
-            for _ in 0..<textFields.count {
+            for i in 0..<textFields.count {
                 textFieldValue.append(" ")
-                highlight.append(Color.clear)
+                if textFields[i].required {
+                    requiredFieldsPresent = true
+                }
+                //highlight.append(Color.clear)
             }
         }
         if cloptions.hideIcon.present {
@@ -39,7 +44,7 @@ struct TextEntryView: View {
                 ForEach(0..<textFields.count, id: \.self) {index in
                     HStack {
                         Spacer()
-                        Text(textFields[index].title)
+                        Text(textFields[index].title + (textFields[index].required ? " *":""))
                             .bold()
                             .font(.system(size: 15))
                             .frame(idealWidth: fieldwidth*0.20, maxWidth: 150, alignment: .leading)
@@ -51,19 +56,12 @@ struct TextEntryView: View {
                                     SecureField("", text: $textFieldValue[index])
                                         .disableAutocorrection(true)
                                         .textContentType(.password)
-                                        //.border(highlight[index])
-                                        .overlay(RoundedRectangle(cornerRadius: 5)
-                                                    .stroke(observedDialogContent.requiredTextfieldHighlight[index], lineWidth: 1))
-
                                     Image(systemName: "lock.fill")
                                         .foregroundColor(stringToColour("#008815")).opacity(0.5)
                                             .frame(idealWidth: fieldwidth*0.50, maxWidth: 300, alignment: .trailing)
                                 }
                             } else {
                                 TextField("", text: $textFieldValue[index])
-                                    //.border(highlight[index])
-                                    .overlay(RoundedRectangle(cornerRadius: 5)
-                                                .stroke(observedDialogContent.requiredTextfieldHighlight[index], lineWidth: 1))
                             }
                         }
                         .frame(idealWidth: fieldwidth*0.50, maxWidth: 300, alignment: .trailing)
@@ -71,7 +69,22 @@ struct TextEntryView: View {
                             //update appvars with the text that was entered. this will be printed to stdout on exit
                             textFields[index].value = textFieldValue[index]
                         })
+                        .overlay(RoundedRectangle(cornerRadius: 5)
+                                    .stroke(observedDialogContent.requiredTextfieldHighlight[index], lineWidth: 1)
+                                    .animation(.easeIn(duration: 0.2)
+                                                .repeatCount(3, autoreverses: true)
+                                               )
+                                 )
                         Spacer()
+                    }
+                }
+                if requiredFieldsPresent {
+                    HStack {
+                        Spacer()
+                        Text("* Required Fields")
+                            .font(.system(size: 10)
+                                    .weight(.light))
+                            .padding(.trailing, 10)
                     }
                 }
             }

--- a/dialog/UI/TextEntryView.swift
+++ b/dialog/UI/TextEntryView.swift
@@ -22,7 +22,7 @@ struct TextEntryView: View {
     init() {
         if cloptions.textField.present {
             textFieldPresent = true
-            for i in 0..<textFieldLabels.count {
+            for i in 0..<textFields.count {
                 textFieldValue.append(" ")
                 highlight.append(Color.clear)
                 if textFields[i].required {
@@ -35,6 +35,7 @@ struct TextEntryView: View {
         } else {
             fieldwidth = appvars.windowWidth - appvars.iconWidth
         }
+        print("highlight array is \(highlight)")
     }
     
     var body: some View {
@@ -46,7 +47,7 @@ struct TextEntryView: View {
                         Text(textFields[j].title)
                             .bold()
                             .font(.system(size: 15))
-                            .frame(idealWidth: fieldwidth*0.20, maxWidth: 90, alignment: .leading)
+                            .frame(idealWidth: fieldwidth*0.20, alignment: .leading)
                         Spacer()
                             .frame(width: 20)
                         HStack {
@@ -58,7 +59,7 @@ struct TextEntryView: View {
                                     .border(highlight[j])
                             }
                         }
-                        .frame(idealWidth: fieldwidth*0.50, maxWidth: 200, alignment: .trailing)
+                        .frame(idealWidth: fieldwidth*0.50, alignment: .trailing)
                         .onChange(of: textFieldValuej[j], perform: { value in
                             //update appvars with the text that was entered. this will be printed to stdout on exit
                             textFields[j].value = textFieldValuej[j]

--- a/dialog/UI/TextEntryView.swift
+++ b/dialog/UI/TextEntryView.swift
@@ -14,6 +14,7 @@ struct TextEntryView: View {
     //var textFieldLabel = CLOptionText(OptionName: cloptions.textField)
     let textFieldLabels = appvars.textOptionsArray
     var textFieldPresent: Bool = false
+    var fieldwidth: CGFloat = 0
     
     
     init() {
@@ -22,6 +23,11 @@ struct TextEntryView: View {
             for _ in textFieldLabels {
                 textFieldValue.append(" ")
             }
+        }
+        if cloptions.hideIcon.present {
+            fieldwidth = appvars.windowWidth
+        } else {
+            fieldwidth = appvars.windowWidth - appvars.iconWidth
         }
     }
     
@@ -34,7 +40,7 @@ struct TextEntryView: View {
                         Text(String(textFieldLabels[i]).components(separatedBy: ",")[0])
                             .bold()
                             .font(.system(size: 15))
-                            .frame(width: appvars.windowWidth/5, alignment: .leading)
+                            .frame(idealWidth: fieldwidth*0.20, maxWidth: 90, alignment: .leading)
                         Spacer()
                             .frame(width: 20)
                         HStack {
@@ -44,7 +50,7 @@ struct TextEntryView: View {
                                 TextField("", text: $textFieldValue[i])
                             }
                         }
-                        .frame(width: appvars.windowWidth/3, alignment: .trailing)
+                        .frame(idealWidth: fieldwidth*0.50, maxWidth: 200, alignment: .trailing)
                         .onChange(of: textFieldValue[i], perform: { value in
                             //update appvars with the text that was entered. this will be printed to stdout on exit
                             appvars.textFieldText[i] = textFieldValue[i]
@@ -52,7 +58,7 @@ struct TextEntryView: View {
                         Spacer()
                     }
                 }
-            }//.frame(maxWidth: 500)
+            }
         }
     }
 }

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -14,8 +14,15 @@ var iconVisible: Bool = true
 
 // declare our app var in case we want to update values - e.g. future use, multiple dialog sizes
 var appvars = AppVariables()
-
 var cloptions = CLOptions()
+var textFields = [TextFieldState]()
+
+struct TextFieldState {
+    var title       : String
+    var required    : Bool      = false
+    var secure      : Bool      = false
+    var value       : String    = ""
+}
 
 struct AppVariables {
     

--- a/dialog/extras/ProcessCLOptions.swift
+++ b/dialog/extras/ProcessCLOptions.swift
@@ -80,10 +80,14 @@ func processCLOptions() {
     if cloptions.textField.present {
         if json[cloptions.textField.long].exists() {
             for i in 0..<json[cloptions.textField.long].arrayValue.count {
-                textFields.append(TextFieldState(title: String(json[cloptions.textField.long][i]["title"].stringValue),
+                if json[cloptions.textField.long][i]["title"].stringValue == "" {
+                    textFields.append(TextFieldState(title: String(json[cloptions.textField.long][i].stringValue)))
+                } else {
+                    textFields.append(TextFieldState(title: String(json[cloptions.textField.long][i]["title"].stringValue),
                                                  required: Bool(json[cloptions.textField.long][i]["required"].boolValue),
                                                  secure: Bool(json[cloptions.textField.long][i]["secure"].boolValue))
                                 )
+                }
             }
         } else {
             for textFieldOption in CLOptionMultiOptions(optionName: cloptions.textField.long) {

--- a/dialog/extras/ProcessCLOptions.swift
+++ b/dialog/extras/ProcessCLOptions.swift
@@ -77,14 +77,34 @@ func processCLOptions() {
     
     }
     
-    
     if cloptions.textField.present {
         if json[cloptions.textField.long].exists() {
-            appvars.textOptionsArray = json[cloptions.textField.long].arrayValue.map {$0.stringValue}
+            for i in 0..<json[cloptions.textField.long].arrayValue.count {
+                textFields.append(TextFieldState(title: String(json[cloptions.textField.long][i]["title"].stringValue),
+                                                 required: Bool(json[cloptions.textField.long][i]["required"].boolValue),
+                                                 secure: Bool(json[cloptions.textField.long][i]["secure"].boolValue))
+                                )
+            }
         } else {
-            appvars.textOptionsArray =  CLOptionMultiOptions(optionName: cloptions.textField.long)
+            for textFieldOption in CLOptionMultiOptions(optionName: cloptions.textField.long) {
+                let items = textFieldOption.components(separatedBy: ",")
+                var fieldTitle : String = ""
+                var fieldSecure : Bool = false
+                var fieldRequire : Bool = false
+                for item in items {
+                    switch item.lowercased() {
+                    case "secure":
+                        fieldSecure = true
+                    case "required":
+                        fieldRequire = true
+                    default:
+                        fieldTitle = item
+                    }
+                }
+                textFields.append(TextFieldState(title: fieldTitle, required: fieldRequire, secure: fieldSecure))
+            }
         }
-        logger(logMessage: "textOptionsArray : \(appvars.textOptionsArray)")
+        logger(logMessage: "textOptionsArray : \(textFields)")
     }
     
     if cloptions.checkbox.present {

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -174,9 +174,9 @@ func quitDialog(exitCode: Int32, exitMessage: String? = "") {
             json["SelectedIndex"].int = appvars.selectedIndex
         }
         if cloptions.textField.present {
-            for i in 0..<appvars.textOptionsArray.count {
-                outputArray.append("\"\(appvars.textOptionsArray[i])\" : \"\(appvars.textFieldText[i])\"")
-                json[appvars.textOptionsArray[i]].string = appvars.textFieldText[i]
+            for i in 0..<textFields.count {
+                outputArray.append("\"\(textFields[i].title)\" : \"\(textFields[i].value)\"")
+                json[textFields[i].title].string = textFields[i].value
             }
         }
         if cloptions.checkbox.present {

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -174,12 +174,15 @@ func quitDialog(exitCode: Int32, exitMessage: String? = "", observedObject : Dia
             json["SelectedIndex"].int = appvars.selectedIndex
         }
         if cloptions.textField.present {
+            // check to see if fields marked as required have content before allowing the app to exit
+            // if there is an empty field, update the highlight colour
             var dontQuit = false
             for i in 0..<textFields.count {
-                
                 if textFields[i].required && textFields[i].value == "" {
                     observedObject?.requiredTextfieldHighlight[i] = Color.red.opacity(0.7)
                     dontQuit = true
+                } else {
+                    observedObject?.requiredTextfieldHighlight[i] = Color.clear
                 }
                 outputArray.append("\"\(textFields[i].title)\" : \"\(textFields[i].value)\"")
                 json[textFields[i].title].string = textFields[i].value

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -107,7 +107,7 @@ func shell(_ command: String) -> String {
     return output
 }
 
-func buttonAction(action: String, exitCode: Int32, executeShell: Bool, shouldQuit: Bool = true) {
+func buttonAction(action: String, exitCode: Int32, executeShell: Bool, shouldQuit: Bool = true, observedObject: DialogUpdatableContent? = nil) {
     //let action: String = CLOptionText(OptionName: cloptions.button1ActionOption, DefaultValue: "")
     
     if (action != "") {
@@ -118,7 +118,7 @@ func buttonAction(action: String, exitCode: Int32, executeShell: Bool, shouldQui
         }
     }
     if shouldQuit {
-        quitDialog(exitCode: exitCode)
+        quitDialog(exitCode: exitCode, observedObject: observedObject)
     }
     //exit(0)
 }
@@ -150,7 +150,7 @@ func getVersionString() -> String {
     return appVersion
 }
 
-func quitDialog(exitCode: Int32, exitMessage: String? = "") {
+func quitDialog(exitCode: Int32, exitMessage: String? = "", observedObject : DialogUpdatableContent? = nil) {
     //var userOutput: Bool = false
     if exitMessage != "" {
         //print(exitCode)
@@ -174,10 +174,17 @@ func quitDialog(exitCode: Int32, exitMessage: String? = "") {
             json["SelectedIndex"].int = appvars.selectedIndex
         }
         if cloptions.textField.present {
+            var dontQuit = false
             for i in 0..<textFields.count {
+                
+                if textFields[i].required && textFields[i].value == "" {
+                    observedObject?.requiredTextfieldHighlight[i] = Color.red.opacity(0.7)
+                    dontQuit = true
+                }
                 outputArray.append("\"\(textFields[i].title)\" : \"\(textFields[i].value)\"")
                 json[textFields[i].title].string = textFields[i].value
             }
+            if dontQuit { return }
         }
         if cloptions.checkbox.present {
             for i in 0..<appvars.checkboxOptionsArray.count {

--- a/dialog/extras/TrackProgress.swift
+++ b/dialog/extras/TrackProgress.swift
@@ -7,6 +7,7 @@
 // concept and execution apropriated from depNotify
 
 import Foundation
+import SwiftUI
 
 enum StatusState {
     case start
@@ -35,6 +36,7 @@ class DialogUpdatableContent : ObservableObject {
     @Published var listItemStatus: [String]
     @Published var listItemUpdateRow: Int
     @Published var listItemPresent: Bool
+    @Published var requiredTextfieldHighlight: [Color] = Array(repeating: Color.clear, count: textFields.count)
     
     var status: StatusState
     
@@ -71,6 +73,8 @@ class DialogUpdatableContent : ObservableObject {
         button2Value = cloptions.button2TextOption.value
         infoButtonValue = cloptions.infoButtonOption.value
         listItemUpdateRow = 0
+        
+        //requiredTextfieldHighlight = Color.clear
         
         iconImage = cloptions.iconOption.value
         


### PR DESCRIPTION
This change adds `secure` and `required` as properties on text fields.

 - `secure` - The text entry field becores a secure field where the text being typed is not shown (aka a password field)
 - `required` - The text field must be populated or swiftDialog will not exit using the OK button. Button 2 (cancel) or button 3 (info) behaviour is not changed
  
With this comes an expansion to how textfields can be defined either as a command line argument or from json

In addition to the existing method, the command line argument can now take the form `--textfield "<field name>,required,secure` where `required` and `secure` are optional.


the JSON formatting can now be expressed like the following

```json
{
  "textfield" : [
    {"title" : "Username", "required" : true},
    {"title" : "Password", "secure" : true, "required" : true},
    {"title" : "Optional Stuff",  "required" : false, "secure" : false}
  ]
}
```

producing the following

<img width="727" alt="image" src="https://user-images.githubusercontent.com/3598965/158047605-468e9fcb-3acb-4f8f-9ca5-4ad96a9659ce.png">

if required fields are not populated, highlights are shown where required with a brief animation when they appear

<img width="727" alt="image" src="https://user-images.githubusercontent.com/3598965/158047633-a63ec3cc-f3a0-4f6f-a174-ec060d337d7e.png">

fixes https://github.com/bartreardon/swiftDialog/issues/87
