### PR TITLE
Multi dropdown

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -749,7 +749,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = "1.10.0 Preview 1";
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -776,7 +776,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = "1.10.0 Preview 1";
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -872,7 +872,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/dialog/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = "1.10.0 Preview 1";
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogcli;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -889,7 +889,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/dialog/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = "1.10.0 Preview 1";
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogcli;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2296</string>
+	<string>2321</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2273</string>
+	<string>2296</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2321</string>
+	<string>2326</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -13,15 +13,9 @@ import Combine
 struct DropdownView: View {
     
     @ObservedObject var observedDialogContent : DialogUpdatableContent
-    
-    //@State var selectedOption = cloptions.dropdownDefault.value
-    @State var selectedOption : [String] //= Array(repeating: "", count: dropdownItems.count)
-    //var defaultOption = Array(repeating: "", count: dropdownItems.count)
+    @State var selectedOption : [String]
 
-    var dropdownValues = appvars.dropdownValuesArray
-    var dropdownTitle: String = cloptions.dropdownTitle.value
     var showDropdown: Bool = cloptions.dropdownValues.present
-    var defaultValue: String = ""
     var fieldwidth: CGFloat = 0
     
     init(observedDialogContent : DialogUpdatableContent) {
@@ -34,13 +28,9 @@ struct DropdownView: View {
         
         var defaultOptions : [String] = []
         for i in 0..<dropdownItems.count {
-            print("default \(i) is \(dropdownItems[i].defaultValue)")
             defaultOptions.append(dropdownItems[i].defaultValue)
-            //selectedOption[i] = State(initialValue: dropdownItems[i].defaultValue) //.init(initialValue: dropdownItems[i].defaultValue)
-            //selectedOption.append(dropdownItems[i].defaultValue)
         }
         _selectedOption = State(initialValue: defaultOptions)
-        print(selectedOption)
     }
         
     var body: some View {
@@ -66,42 +56,14 @@ struct DropdownView: View {
                         .pickerStyle(DefaultPickerStyle())
                         .frame(idealWidth: fieldwidth*0.50, maxWidth: 300, alignment: .trailing)
                         .onChange(of: selectedOption[index]) { _ in
-                            //update appvars with the option that was selected. this will be printed to stdout on exit
-                            //appvars.selectedOption = selectedOption[index]
-                            //appvars.selectedIndex = dropdownValues.firstIndex {$0 == selectedOption[index]} ?? -1
+                            //update dropdownItems with the option that was selected. this will be printed to stdout on exit
+                            dropdownItems[index].selectedValue = selectedOption[index]
                         }
                         Spacer()
                     }
                 }
             }
-            
-            /*
-            HStack {
-                // we could print the title as part of the picker control but then we don't get easy access to swiftui text formatting
-                // so we print it seperatly and use a blank value in the picker
-                Spacer()
-                Text(dropdownTitle)
-                    .bold()
-                    .font(.system(size: 15))
-                    .frame(idealWidth: fieldwidth*0.20, maxWidth: 150, alignment: .leading)
-                Spacer()
-                    .frame(width: 20)
-                Picker("", selection: $selectedOption)
-                {
-                    ForEach(dropdownValues, id: \.self) {
-                        Text($0)
-                    }
-                }
-                .pickerStyle(DefaultPickerStyle())
-                .frame(idealWidth: fieldwidth*0.50, maxWidth: 300, alignment: .trailing)
-                .onChange(of: selectedOption) { _ in
-                    //update appvars with the option that was selected. this will be printed to stdout on exit
-                    appvars.selectedOption = selectedOption
-                    appvars.selectedIndex = dropdownValues.firstIndex {$0 == selectedOption} ?? -1
-                }
-                Spacer()
-            }
-             */
+        
         }
     }
 }

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -12,7 +12,11 @@ import Combine
 
 struct DropdownView: View {
     
-    @State var selectedOption = cloptions.dropdownDefault.value
+    @ObservedObject var observedDialogContent : DialogUpdatableContent
+    
+    //@State var selectedOption = cloptions.dropdownDefault.value
+    @State var selectedOption : [String] //= Array(repeating: "", count: dropdownItems.count)
+    //var defaultOption = Array(repeating: "", count: dropdownItems.count)
 
     var dropdownValues = appvars.dropdownValuesArray
     var dropdownTitle: String = cloptions.dropdownTitle.value
@@ -20,16 +24,58 @@ struct DropdownView: View {
     var defaultValue: String = ""
     var fieldwidth: CGFloat = 0
     
-    init() {
+    init(observedDialogContent : DialogUpdatableContent) {
+        self.observedDialogContent = observedDialogContent
         if cloptions.hideIcon.present {
             fieldwidth = appvars.windowWidth
         } else {
             fieldwidth = appvars.windowWidth - appvars.iconWidth
         }
+        
+        var defaultOptions : [String] = []
+        for i in 0..<dropdownItems.count {
+            print("default \(i) is \(dropdownItems[i].defaultValue)")
+            defaultOptions.append(dropdownItems[i].defaultValue)
+            //selectedOption[i] = State(initialValue: dropdownItems[i].defaultValue) //.init(initialValue: dropdownItems[i].defaultValue)
+            //selectedOption.append(dropdownItems[i].defaultValue)
+        }
+        _selectedOption = State(initialValue: defaultOptions)
+        print(selectedOption)
     }
         
     var body: some View {
         if showDropdown {
+            VStack {
+                ForEach(0..<dropdownItems.count, id: \.self) {index in
+                    HStack {
+                        // we could print the title as part of the picker control but then we don't get easy access to swiftui text formatting
+                        // so we print it seperatly and use a blank value in the picker
+                        Spacer()
+                        Text(dropdownItems[index].title)
+                            .bold()
+                            .font(.system(size: 15))
+                            .frame(idealWidth: fieldwidth*0.20, maxWidth: 150, alignment: .leading)
+                        Spacer()
+                            .frame(width: 20)
+                        Picker("", selection: $selectedOption[index])
+                        {
+                            ForEach(dropdownItems[index].values, id: \.self) {
+                                Text($0)
+                            }
+                        }
+                        .pickerStyle(DefaultPickerStyle())
+                        .frame(idealWidth: fieldwidth*0.50, maxWidth: 300, alignment: .trailing)
+                        .onChange(of: selectedOption[index]) { _ in
+                            //update appvars with the option that was selected. this will be printed to stdout on exit
+                            //appvars.selectedOption = selectedOption[index]
+                            //appvars.selectedIndex = dropdownValues.firstIndex {$0 == selectedOption[index]} ?? -1
+                        }
+                        Spacer()
+                    }
+                }
+            }
+            
+            /*
             HStack {
                 // we could print the title as part of the picker control but then we don't get easy access to swiftui text formatting
                 // so we print it seperatly and use a blank value in the picker
@@ -55,6 +101,7 @@ struct DropdownView: View {
                 }
                 Spacer()
             }
+             */
         }
     }
 }

--- a/dialog/UI/MessageContentView.swift
+++ b/dialog/UI/MessageContentView.swift
@@ -94,7 +94,7 @@ struct MessageContent: View {
                             .padding(.bottom, 10)
                             .border(appvars.debugBorderColour, width: 2)
 
-                        DropdownView()
+                        DropdownView(observedDialogContent: observedDialogContent)
                             //.padding(.leading, 50)
                             //.padding(.trailing, 50)
                             .padding(.bottom, 10)

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -16,17 +16,24 @@ var iconVisible: Bool = true
 var appvars = AppVariables()
 var cloptions = CLOptions()
 var textFields = [TextFieldState]()
+var dropdownItems = [DropDownItems]()
 
 struct TextFieldState {
-    var title       : String
-    var required    : Bool      = false
-    var secure      : Bool      = false
-    var value       : String    = ""
+    var title           : String
+    var required        : Bool      = false
+    var secure          : Bool      = false
+    var value           : String    = ""
+}
+
+struct DropDownItems {
+    var title           : String
+    var values          : [String]
+    var defaultValue    : String
 }
 
 struct AppVariables {
     
-    var cliversion                      = String("1.10.0")
+    var cliversion                      = String("1.10.0 Preview 1")
     
     // message default strings
     var titleDefault                    = String("An Important Message")
@@ -91,6 +98,8 @@ struct AppVariables {
     var selectedOption                  = ""
     var selectedIndex                   = 0
     var dropdownValuesArray             = [String]()
+    
+    var dropdownOptionArray             = [Any]()
 
     var jsonOut                         = Bool(false)
     

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -29,6 +29,7 @@ struct DropDownItems {
     var title           : String
     var values          : [String]
     var defaultValue    : String
+    var selectedValue   : String = ""
 }
 
 struct AppVariables {

--- a/dialog/extras/ProcessCLOptions.swift
+++ b/dialog/extras/ProcessCLOptions.swift
@@ -62,30 +62,35 @@ func processCLOptions() {
     let json : JSON = getJSON()
     
     if cloptions.dropdownValues.present {
-        if json[cloptions.dropdownValues.long].exists() {
-            appvars.dropdownValuesArray = json[cloptions.dropdownValues.long].arrayValue.map {$0.stringValue}
-        } else {
-            let dropdownValues = cloptions.dropdownValues.value.components(separatedBy: ",")
-            appvars.dropdownValuesArray = dropdownValues.map { $0.trimmingCharacters(in: .whitespaces) } // trim out any whitespace from the values if there were spaces before after the comma
+        // checking for the pre 1.10 way of defining a select list
+        if json[cloptions.dropdownValues.long].exists() && !json["selectitems"].exists() {
+            let selectValues = json[cloptions.dropdownValues.long].stringValue.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            let selectTitle = json[cloptions.dropdownTitle.long].stringValue
+            let selectDefault = json[cloptions.dropdownDefault.long].stringValue
+            dropdownItems.append(DropDownItems(title: selectTitle, values: selectValues, defaultValue: selectDefault, selectedValue: selectDefault))
+            print(dropdownItems)
+        }
+        
+        if json["selectitems"].exists() {            
+            for i in 0..<json["selectitems"].count {
+                
+                let selectTitle = json["selectitems"][i]["title"].stringValue
+                let selectValues = (json["selectitems"][i]["values"].arrayValue.map {$0.stringValue}).map { $0.trimmingCharacters(in: .whitespaces) }
+                let selectDefault = json["selectitems"][i]["default"].stringValue
+                
+                dropdownItems.append(DropDownItems(title: selectTitle, values: selectValues, defaultValue: selectDefault, selectedValue: selectDefault))
+            }
             
+        } else {
             let dropdownOptions = CLOptionMultiOptions(optionName: cloptions.dropdownValues.long)
-            let dropdownLabels = CLOptionMultiOptions(optionName: cloptions.dropdownTitle.long)
+            var selectValues = CLOptionMultiOptions(optionName: cloptions.dropdownTitle.long)
+            selectValues = selectValues.map { $0.trimmingCharacters(in: .whitespaces) }
             let dropdownDefaults = CLOptionMultiOptions(optionName: cloptions.dropdownDefault.long)
 
             for i in 0..<(dropdownOptions.count) {
-                dropdownItems.append(DropDownItems(title: dropdownLabels[i], values: dropdownOptions[i].components(separatedBy: ","), defaultValue: dropdownDefaults[i]))
+                dropdownItems.append(DropDownItems(title: selectValues[i], values: dropdownOptions[i].components(separatedBy: ","), defaultValue: dropdownDefaults[i], selectedValue: dropdownDefaults[i]))
             }
-            print(dropdownOptions)
-            print(dropdownLabels)
-            print(dropdownDefaults)
-            print(dropdownItems)
         }
-    
-        if json[cloptions.dropdownDefault.long].exists() || cloptions.dropdownDefault.present {
-            appvars.selectedOption = cloptions.dropdownDefault.value
-            appvars.selectedIndex = appvars.dropdownValuesArray.firstIndex {$0 == cloptions.dropdownDefault.value} ?? -1
-        }
-    
     }
     
     if cloptions.textField.present {
@@ -102,7 +107,7 @@ func processCLOptions() {
             }
         } else {
             for textFieldOption in CLOptionMultiOptions(optionName: cloptions.textField.long) {
-                let items = textFieldOption.components(separatedBy: ",")
+                let items = textFieldOption.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
                 var fieldTitle : String = ""
                 var fieldSecure : Bool = false
                 var fieldRequire : Bool = false
@@ -456,13 +461,13 @@ func processCLOptionValues() {
     cloptions.buttonInfoActionOption.value  = json[cloptions.buttonInfoActionOption.long].string ?? CLOptionText(OptionName: cloptions.buttonInfoActionOption)
     cloptions.buttonInfoActionOption.present = json[cloptions.buttonInfoActionOption.long].exists() || CLOptionPresent(OptionName: cloptions.buttonInfoActionOption)
 
-    cloptions.dropdownTitle.value           = json[cloptions.dropdownTitle.long].string ?? CLOptionText(OptionName: cloptions.dropdownTitle)
+    //cloptions.dropdownTitle.value           = json[cloptions.dropdownTitle.long].string ?? CLOptionText(OptionName: cloptions.dropdownTitle)
     cloptions.dropdownTitle.present         = json[cloptions.dropdownTitle.long].exists() || CLOptionPresent(OptionName: cloptions.dropdownTitle)
 
-    cloptions.dropdownValues.value          = json[cloptions.dropdownValues.long].string ?? CLOptionText(OptionName: cloptions.dropdownValues)
-    cloptions.dropdownValues.present        = json[cloptions.dropdownValues.long].exists() || CLOptionPresent(OptionName: cloptions.dropdownValues)
+    //cloptions.dropdownValues.value          = json[cloptions.dropdownValues.long].string ?? CLOptionText(OptionName: cloptions.dropdownValues)
+    cloptions.dropdownValues.present        = json["selectitems"].exists() || json[cloptions.dropdownValues.long].exists() || CLOptionPresent(OptionName: cloptions.dropdownValues)
 
-    cloptions.dropdownDefault.value         = json[cloptions.dropdownDefault.long].string ?? CLOptionText(OptionName: cloptions.dropdownDefault)
+    //cloptions.dropdownDefault.value         = json[cloptions.dropdownDefault.long].string ?? CLOptionText(OptionName: cloptions.dropdownDefault)
     cloptions.dropdownDefault.present       = json[cloptions.dropdownDefault.long].exists() || CLOptionPresent(OptionName: cloptions.dropdownDefault)
 
     cloptions.titleFont.value               = json[cloptions.titleFont.long].string ?? CLOptionText(OptionName: cloptions.titleFont)

--- a/dialog/extras/ProcessCLOptions.swift
+++ b/dialog/extras/ProcessCLOptions.swift
@@ -65,9 +65,20 @@ func processCLOptions() {
         if json[cloptions.dropdownValues.long].exists() {
             appvars.dropdownValuesArray = json[cloptions.dropdownValues.long].arrayValue.map {$0.stringValue}
         } else {
-    
             let dropdownValues = cloptions.dropdownValues.value.components(separatedBy: ",")
             appvars.dropdownValuesArray = dropdownValues.map { $0.trimmingCharacters(in: .whitespaces) } // trim out any whitespace from the values if there were spaces before after the comma
+            
+            let dropdownOptions = CLOptionMultiOptions(optionName: cloptions.dropdownValues.long)
+            let dropdownLabels = CLOptionMultiOptions(optionName: cloptions.dropdownTitle.long)
+            let dropdownDefaults = CLOptionMultiOptions(optionName: cloptions.dropdownDefault.long)
+
+            for i in 0..<(dropdownOptions.count) {
+                dropdownItems.append(DropDownItems(title: dropdownLabels[i], values: dropdownOptions[i].components(separatedBy: ","), defaultValue: dropdownDefaults[i]))
+            }
+            print(dropdownOptions)
+            print(dropdownLabels)
+            print(dropdownDefaults)
+            print(dropdownItems)
         }
     
         if json[cloptions.dropdownDefault.long].exists() || cloptions.dropdownDefault.present {

--- a/dialog/extras/ProcessCLOptions.swift
+++ b/dialog/extras/ProcessCLOptions.swift
@@ -82,13 +82,23 @@ func processCLOptions() {
             }
             
         } else {
-            let dropdownOptions = CLOptionMultiOptions(optionName: cloptions.dropdownValues.long)
+            let dropdownValues = CLOptionMultiOptions(optionName: cloptions.dropdownValues.long)
             var selectValues = CLOptionMultiOptions(optionName: cloptions.dropdownTitle.long)
-            selectValues = selectValues.map { $0.trimmingCharacters(in: .whitespaces) }
-            let dropdownDefaults = CLOptionMultiOptions(optionName: cloptions.dropdownDefault.long)
-
-            for i in 0..<(dropdownOptions.count) {
-                dropdownItems.append(DropDownItems(title: selectValues[i], values: dropdownOptions[i].components(separatedBy: ","), defaultValue: dropdownDefaults[i], selectedValue: dropdownDefaults[i]))
+            var dropdownDefaults = CLOptionMultiOptions(optionName: cloptions.dropdownDefault.long)
+            print(dropdownValues.count)
+            print(selectValues.count)
+            print(dropdownDefaults.count)
+            
+            // need to make sure the title and default value arrays are the same size
+            for _ in selectValues.count..<dropdownValues.count {
+                selectValues.append("")
+            }
+            for _ in dropdownDefaults.count..<dropdownValues.count {
+                dropdownDefaults.append("")
+            }
+            
+            for i in 0..<(dropdownValues.count) {
+                dropdownItems.append(DropDownItems(title: selectValues[i], values: dropdownValues[i].components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }, defaultValue: dropdownDefaults[i], selectedValue: dropdownDefaults[i]))
             }
         }
     }

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -12,11 +12,6 @@ import SwiftUI
 import OSLog
 import SwiftyJSON
 
-class stdOutput: ObservableObject {
-    @Published var selectedOption: String = ""
-}
-
-
 public extension Color {
 
     static let background = Color(NSColor.windowBackgroundColor)
@@ -165,12 +160,21 @@ func quitDialog(exitCode: Int32, exitMessage: String? = "", observedObject : Dia
         
         //build output array
         var outputArray : Array = [String]()
-        if appvars.selectedOption != "" {
-            outputArray.append("\"SelectedOption\" : \"\(appvars.selectedOption)\"")
-            json["SelectedOption"].string = appvars.selectedOption
-            outputArray.append("\"SelectedIndex\" : \(appvars.selectedIndex)")
-            json["SelectedIndex"].int = appvars.selectedIndex
+        
+        if cloptions.dropdownValues.present {
+            if dropdownItems.count == 1 {
+                outputArray.append("\"SelectedOption\" : \"\(dropdownItems[0].selectedValue)\"")
+                json["SelectedOption"].string = dropdownItems[0].selectedValue
+                outputArray.append("\"SelectedIndex\" : \(dropdownItems[0].values.firstIndex(of: dropdownItems[0].selectedValue) ?? -1)")
+                json["SelectedIndex"].int = dropdownItems[0].values.firstIndex(of: dropdownItems[0].selectedValue) ?? -1
+            }
+            for i in 0..<dropdownItems.count {
+                outputArray.append("\"\(dropdownItems[i].title)\" : \"\(dropdownItems[i].selectedValue)\"")
+                outputArray.append("\"\(dropdownItems[i].title)\" index : \"\(dropdownItems[i].values.firstIndex(of: dropdownItems[i].selectedValue) ?? -1)\"")
+                json[dropdownItems[i].title] = ["selectedValue" : dropdownItems[i].selectedValue, "selectedIndex" : dropdownItems[i].values.firstIndex(of: dropdownItems[i].selectedValue) ?? -1]
+            }
         }
+        
         if cloptions.textField.present {
             // check to see if fields marked as required have content before allowing the app to exit
             // if there is an empty field, update the highlight colour


### PR DESCRIPTION
adds multiple dropdown support.

<img width="727" alt="image" src="https://user-images.githubusercontent.com/3598965/159146203-31390a37-6ee5-4ea3-95dd-92ba47c8ac13.png">

as command line argument add multiple  `--selecttitle`, `--selectvalues` and `--selectdefault`. values, titles and defaults are assigned in the order they are presented

as json:

```json
"selectitems" : [
    {"title" : "Select 1", "values" : ["one","two","three"]},
    {"title" : "Select 2", "values" : ["red","green","blue"], "default" : "red"},
    {"title" : "Select 3", "values" : ["up","down","left","right"]}
  ]
```

results:
```bash
Select 1 : one
Select 1 index : 0
Select 2 : green
Select 2 index : 1
Select 3 : left
Select 3 index : 2
```

results as json output:

```json
{
  "Select 2" : {
    "selectedIndex" : 1,
    "selectedValue" : "green"
  },
  "Select 1" : {
    "selectedIndex" : 0,
    "selectedValue" : "one"
  },
  "Select 3" : {
    "selectedIndex" : 2,
    "selectedValue" : "left"
  }
}
```

the [previous method](https://github.com/bartreardon/swiftDialog/wiki/Selectable-Lists) for adding a dropdown and reading the result will still work for single dropdowns to maintain compatibility
