### PR TITLE
fixed window activation logic

### DIFF
--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2429</string>
+	<string>2432</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -88,6 +88,8 @@ struct dialogApp: App {
         
         observedDialogContent = DialogUpdatableContent()
         
+        // bring to front on launch
+        NSApp.activate(ignoringOtherApps: true)
     }
     var body: some Scene {
 
@@ -110,7 +112,10 @@ struct dialogApp: App {
                         NSApp.windows[0].level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
                     }
                     
-                    NSApp.activate(ignoringOtherApps: true)
+                    if cloptions.forceOnTop.present || cloptions.blurScreen.present {
+                        NSApp.activate(ignoringOtherApps: true)
+                    }
+                    
                 }
                 .frame(width: 0, height: 0) //ensures hostingwindowfinder isn't taking up any real estate
                 


### PR DESCRIPTION
fixed the window activation logic so the window doesn't steal focus when sending updates to it

if `--ontop` or `--blurscreen` options are present then we can assume we do what that behaviour so in those cases we re-activate the window when an update is sent.