### PR TITLE
Added extra system colours available in macOS 12

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -749,7 +749,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -776,7 +776,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -872,7 +872,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/dialog/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogcli;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -889,7 +889,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/dialog/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogcli;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2429</string>
+	<string>2438</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/UI/IconOverlayView.swift
+++ b/dialog/UI/IconOverlayView.swift
@@ -144,14 +144,24 @@ struct IconOverlayView: View {
                                         .scaledToFit()
                                         .foregroundColor(Color.white)
                                         .font(Font.title.weight(builtInIconWeight))
-
-                                    Image(systemName: builtInIconName)
-                                        .renderingMode(iconRenderingMode)
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                        .scaledToFit()
-                                        .foregroundColor(builtInIconColour)
-                                        .font(Font.title.weight(builtInIconWeight))
+                                    if #available(macOS 12.0, *) {
+                                        Image(systemName: builtInIconName)
+                                            .resizable()
+                                            .renderingMode(iconRenderingMode)
+                                            .font(Font.title.weight(builtInIconWeight))
+                                            .symbolRenderingMode(.hierarchical)
+                                            .foregroundStyle(builtInIconColour)
+                                            .aspectRatio(contentMode: .fit)
+                                            .scaledToFit()
+                                    } else {
+                                        Image(systemName: builtInIconName)
+                                            .renderingMode(iconRenderingMode)
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fit)
+                                            .scaledToFit()
+                                            .foregroundColor(builtInIconColour)
+                                            .font(Font.title.weight(builtInIconWeight))
+                                    }
                                 }
                             }
                         }

--- a/dialog/UI/IconView.swift
+++ b/dialog/UI/IconView.swift
@@ -163,11 +163,21 @@ struct IconView: View {
                         Image(systemName: builtInIconFill)
                             .resizable()
                             .foregroundColor(Color.white)
-                        Image(systemName: builtInIconName)
-                            .resizable()
-                            .renderingMode(iconRenderingMode)
-                            .font(Font.title.weight(builtInIconWeight))
-                            .foregroundColor(builtInIconColour)
+                        if #available(macOS 12.0, *) {
+                            Image(systemName: builtInIconName)
+                                .resizable()
+                                .renderingMode(iconRenderingMode)
+                                .font(Font.title.weight(builtInIconWeight))
+                                .symbolRenderingMode(.hierarchical)
+                                .foregroundStyle(builtInIconColour)
+                        } else {
+                            // Fallback on earlier versions
+                            Image(systemName: builtInIconName)
+                                .resizable()
+                                .renderingMode(iconRenderingMode)
+                                .font(Font.title.weight(builtInIconWeight))
+                                .foregroundColor(builtInIconColour)
+                        }
                     }
                 }
                 .aspectRatio(contentMode: .fit)

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -262,28 +262,53 @@ func stringToColour(_ colourValue: String) -> Color {
         
     } else {
         switch colourValue {
-            case "black":
-                returnColor = Color.black
-            case "blue":
-                returnColor = Color.blue
-            case "gray":
-                returnColor = Color.gray
-            case "green":
-                returnColor = Color.green
-            case "orange":
-                returnColor = Color.orange
-            case "pink":
-                returnColor = Color.pink
-            case "purple":
-                returnColor = Color.purple
-            case "red":
-                returnColor = Color.red
-            case "white":
-                returnColor = Color.white
-            case "yellow":
-                returnColor = Color.yellow
-            default:
-                returnColor = Color.primary
+            
+        case "black":
+            returnColor = Color.black
+        case "blue":
+            returnColor = Color.blue
+        case "gray":
+            returnColor = Color.gray
+        case "green":
+            returnColor = Color.green
+        case "orange":
+            returnColor = Color.orange
+        case "pink":
+            returnColor = Color.pink
+        case "purple":
+            returnColor = Color.purple
+        case "red":
+            returnColor = Color.red
+        case "white":
+            returnColor = Color.white
+        case "yellow":
+            returnColor = Color.yellow
+        case "mint":
+            if #available(macOS 12.0, *) {
+                returnColor = Color.mint
+            } else {
+                returnColor = Color.init(red: 90, green: 196, blue: 198)
+            }
+        case "cyan":
+            if #available(macOS 12.0, *) {
+                returnColor = Color.cyan
+            } else {
+                returnColor = Color.init(red: 114, green: 187, blue: 235)
+            }
+        case "indego":
+            if #available(macOS 12.0, *) {
+                returnColor = Color.indigo
+            } else {
+                returnColor = Color.init(red: 88, green: 86, blue: 207)
+            }
+        case "teal":
+            if #available(macOS 12.0, *) {
+                returnColor = Color.teal
+            } else {
+                returnColor = Color.init(red: 110, green: 171, blue: 193)
+            }
+        default:
+            returnColor = Color.primary
         }
     }
     


### PR DESCRIPTION
on macOS 12, SF Symbols will render using the hierarchical scheme by default with the specified single colour