### PR TITLE
Tweak how banner images are handled. 

### DIFF
--- a/dialog/UI/BannerImageView.swift
+++ b/dialog/UI/BannerImageView.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-import CommonMark
 
 struct BannerImageView: View {
     

--- a/dialog/UI/BannerImageView.swift
+++ b/dialog/UI/BannerImageView.swift
@@ -7,27 +7,30 @@
 
 import Foundation
 import SwiftUI
+import CommonMark
 
 struct BannerImageView: View {
     
-    var BannerImageOption : String = ""
-    var bannerHeight : CGFloat = 0
+    var bannerImage     : NSImage
+    var bannerHeight    : CGFloat = 0
+    var bannerWidth     : CGFloat = 0
     let maxBannerHeight : CGFloat = 150
-    
+        
     init(imagePath: String) {
-        BannerImageOption = imagePath
-        bannerHeight = appvars.windowHeight * 0.2
+        bannerImage = getImageFromPath(fileImagePath: imagePath)
+        bannerWidth = appvars.windowWidth
+        bannerHeight = bannerImage.size.height*(appvars.windowWidth / bannerImage.size.width)
         if bannerHeight > maxBannerHeight {
             bannerHeight = maxBannerHeight
         }
     }
     
     var body: some View {
-        Image(nsImage: getImageFromPath(fileImagePath: BannerImageOption))
+        Image(nsImage: bannerImage)
             .resizable()
             .aspectRatio(contentMode: .fill)
             .scaledToFill()
-            .frame(width: appvars.windowWidth, height: bannerHeight, alignment: .topLeading)
+            .frame(width: bannerWidth, height: bannerHeight, alignment: .topLeading)
             .clipped()
     }
 }

--- a/dialog/UI/ContentView.swift
+++ b/dialog/UI/ContentView.swift
@@ -10,7 +10,7 @@ import Cocoa
 
 struct ContentView: View {
 
-    var bannerAdjustment       = CGFloat(5)
+    var titlePadding       = CGFloat(10)
     var waterMarkFill          = String("")
     var progressSteps : CGFloat = appvars.timerDefaultSeconds
     
@@ -21,6 +21,9 @@ struct ContentView: View {
         self.observedDialogContent = observedDialogContent
         if cloptions.timerBar.present {
             progressSteps = string2float(string: cloptions.timerBar.value)
+        }
+        if cloptions.bannerImage.present {
+            titlePadding = 0
         }
     }
 //
@@ -45,11 +48,13 @@ struct ContentView: View {
                     // Dialog title
                     TitleView(observedDialogContent: observedDialogContent)
                         .border(appvars.debugBorderColour, width: 2)
-                        .offset(y: 10) // shift the title down a notch
+                        .padding(.top, titlePadding)
+                        //.offset(y: 10) // shift the title down a notch
                     
                     // Horozontal Line
                     Divider()
                         .frame(width: appvars.windowWidth*appvars.horozontalLineScale, height: 2)
+                        .offset(y: -10) // shift the divider up a notch
                 }
                 
                 if cloptions.video.present {


### PR DESCRIPTION
Will now adjust to the dimensions of the banner image to a maximum height of 150. This makes using arbitrary banner style images easier over multiple window sizes without needing to work out the optimal image dimensions.

Also adjusted the position of the title text when a banner image is being used.