### PR TITLE
Corrected --commandFile default value

### DIFF
--- a/dialog/extras/helpText.swift
+++ b/dialog/extras/helpText.swift
@@ -234,7 +234,7 @@ var helpText = """
     
         --\(cloptions.statusLogFile.long) <file>
                     Sets the path to the command file Dialog will read from to receive updates
-                    Default file is /var/log/dialog.log
+                    Default file is /var/tmp/dialog.log
 
         -\(cloptions.bannerImage.short), --\(cloptions.bannerImage.long) <file> | <url>
                     Shows a banner image at the top of the dialog


### PR DESCRIPTION
The default value of --commandFile was incorrectly shown as /var/log/dialog.log. It should instead be /var/tmp/dialog.log.